### PR TITLE
css直接写入图片文件,解决外部文件无权限问题 fix #44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,15 @@
 {
     "name": "background-cover",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@types/mime-types": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
+            "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM=",
+            "dev": true
+        },
         "@types/mocha": {
             "version": "5.2.7",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
@@ -365,18 +371,16 @@
             }
         },
         "mime-db": {
-            "version": "1.40.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
-            "dev": true
+            "version": "1.46.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+            "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
         },
         "mime-types": {
-            "version": "2.1.24",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
-            "dev": true,
+            "version": "2.1.29",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+            "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
             "requires": {
-                "mime-db": "1.40.0"
+                "mime-db": "1.46.0"
             }
         },
         "minimatch": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "background-cover",
     "displayName": "background-cover",
     "description": "Add a picture you like to cover the entire vscode..",
-    "version": "2.2.4",
+    "version": "2.2.5",
     "publisher": "manasxx",
     "engines": {
         "vscode": "^1.38.0"
@@ -24,7 +24,9 @@
     ],
     "license": "ISC",
     "main": "./out/extension",
-    "extensionKind": ["ui"],
+    "extensionKind": [
+        "ui"
+    ],
     "contributes": {
         "commands": [
             {
@@ -89,9 +91,13 @@
         "check": "tslint -p ./"
     },
     "devDependencies": {
+        "@types/mime-types": "^2.1.0",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.0.8",
         "typescript": "3.5",
         "vscode": "^1.1.34"
+    },
+    "dependencies": {
+        "mime-types": "^2.1.29"
     }
 }

--- a/src/FileDom.ts
+++ b/src/FileDom.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import version from './version';
 import * as vscode from 'vscode';
+import * as mimeTypes from 'mime-types';
 
 const cssName: string = vscode.version >= "1.38" ? 'workbench.desktop.main.css' : 'workbench.main.css';
 export class FileDom {
@@ -40,6 +41,8 @@ export class FileDom {
 		opacity = 0.79 + (0.2 - ((opacity * 2) / 10));
 
 		let imagePath = this.imagePath.replace(/\\/g, '/');
+		let imageData = new Buffer(fs.readFileSync(imagePath)).toString("base64");
+		let imageBase64 = `data:${mimeTypes.lookup(imagePath)};base64,${imageData}`;
 
 		return `
 		/*ext-${this.extName}-start*/
@@ -48,7 +51,7 @@ export class FileDom {
 			background-size:cover;
 			background-repeat: no-repeat;
 			opacity:${opacity};
-			background-image:url('${imagePath}');
+			background-image:url('${imageBase64}');
 		}
 		/*ext-${this.extName}-end*/
 		`;


### PR DESCRIPTION
---
本来是想把图片文件复制到一个有权限的位置再设置成路径的...
然后发现这插件有随机切换图片的功能  图片可能不只是一个...
最后直接把图片base64编码直接写到css里暴力解决2333

--- 
bilibili 暮光小猿wzt