### PR TITLE
背景图片设置云同步+程序升级自动重设置

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,494 @@
 {
     "name": "background-cover",
     "version": "2.2.5",
-    "lockfileVersion": 1,
+    "lockfileVersion": 2,
     "requires": true,
+    "packages": {
+        "": {
+            "name": "background-cover",
+            "version": "2.2.5",
+            "hasInstallScript": true,
+            "license": "ISC",
+            "devDependencies": {
+                "@types/mocha": "^5.2.7",
+                "@types/node": "^12.20.12",
+                "typescript": "3.5",
+                "vscode": "^1.1.37"
+            },
+            "engines": {
+                "vscode": "^1.38.0"
+            }
+        },
+        "node_modules/@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npm.taobao.org/@tootallnate/once/download/@tootallnate/once-1.1.2.tgz",
+            "integrity": "sha1-zLkURTYBeaBOf+av94wA/8Hur4I=",
+            "dev": true,
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/@types/mocha": {
+            "version": "5.2.7",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
+            "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+            "dev": true
+        },
+        "node_modules/@types/node": {
+            "version": "12.20.12",
+            "resolved": "https://registry.nlark.com/@types/node/download/@types/node-12.20.12.tgz",
+            "integrity": "sha1-/ZwcLPq1NqI4PtHvcPlK3qdDoiY=",
+            "dev": true
+        },
+        "node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npm.taobao.org/agent-base/download/agent-base-6.0.2.tgz",
+            "integrity": "sha1-Sf/1hXfP7j83F2/qtMIuAPhtf3c=",
+            "dev": true,
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npm.taobao.org/balanced-match/download/balanced-match-1.0.2.tgz?cache=0&sync_timestamp=1617714298273&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbalanced-match%2Fdownload%2Fbalanced-match-1.0.2.tgz",
+            "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
+            "dev": true
+        },
+        "node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npm.taobao.org/brace-expansion/download/brace-expansion-1.1.11.tgz?cache=0&sync_timestamp=1614010713935&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fbrace-expansion%2Fdownload%2Fbrace-expansion-1.1.11.tgz",
+            "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/browser-stdout": {
+            "version": "1.3.1",
+            "resolved": "http://registry.npm.taobao.org/browser-stdout/download/browser-stdout-1.3.1.tgz",
+            "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+            "dev": true
+        },
+        "node_modules/buffer-from": {
+            "version": "1.1.1",
+            "resolved": "http://registry.npm.taobao.org/buffer-from/download/buffer-from-1.1.1.tgz",
+            "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
+            "dev": true
+        },
+        "node_modules/commander": {
+            "version": "2.15.1",
+            "resolved": "https://registry.nlark.com/commander/download/commander-2.15.1.tgz?cache=0&sync_timestamp=1618847174396&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fcommander%2Fdownload%2Fcommander-2.15.1.tgz",
+            "integrity": "sha1-30boZ9D8Kuxmo0ZitAapzK//Ww8=",
+            "dev": true
+        },
+        "node_modules/concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npm.taobao.org/concat-map/download/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "node_modules/debug": {
+            "version": "4.3.1",
+            "resolved": "https://registry.nlark.com/debug/download/debug-4.3.1.tgz?cache=0&sync_timestamp=1618847016785&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fdebug%2Fdownload%2Fdebug-4.3.1.tgz",
+            "integrity": "sha1-8NIpxQXgxtjEmsVT0bE9wYP2su4=",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            }
+        },
+        "node_modules/diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.nlark.com/diff/download/diff-3.5.0.tgz",
+            "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.3.1"
+            }
+        },
+        "node_modules/es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npm.taobao.org/es6-promise/download/es6-promise-4.2.8.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fes6-promise%2Fdownload%2Fes6-promise-4.2.8.tgz",
+            "integrity": "sha1-TrIVlMlyvEBVPSduUQU5FD21Pgo=",
+            "dev": true
+        },
+        "node_modules/es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npm.taobao.org/es6-promisify/download/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "dependencies": {
+                "es6-promise": "^4.0.3"
+            }
+        },
+        "node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npm.taobao.org/escape-string-regexp/download/escape-string-regexp-1.0.5.tgz?cache=0&sync_timestamp=1618677243201&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fescape-string-regexp%2Fdownload%2Fescape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npm.taobao.org/fs.realpath/download/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "node_modules/glob": {
+            "version": "7.1.7",
+            "resolved": "https://registry.nlark.com/glob/download/glob-7.1.7.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fglob%2Fdownload%2Fglob-7.1.7.tgz",
+            "integrity": "sha1-Oxk+kjPwHULQs/eClLvutBj5SpA=",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/growl": {
+            "version": "1.10.5",
+            "resolved": "http://registry.npm.taobao.org/growl/download/growl-1.10.5.tgz",
+            "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+            "dev": true,
+            "engines": {
+                "node": ">=4.x"
+            }
+        },
+        "node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz?cache=0&sync_timestamp=1618559697170&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fhas-flag%2Fdownload%2Fhas-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true,
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/he": {
+            "version": "1.1.1",
+            "resolved": "http://registry.npm.taobao.org/he/download/he-1.1.1.tgz",
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+            "dev": true,
+            "bin": {
+                "he": "bin/he"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npm.taobao.org/http-proxy-agent/download/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha1-ioyO9/WTLM+VPClsqCkblap0qjo=",
+            "dev": true,
+            "dependencies": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npm.taobao.org/https-proxy-agent/download/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha1-4qkFQqu2inYuCghQ9sntrf2FBrI=",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npm.taobao.org/inflight/download/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "dependencies": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+            }
+        },
+        "node_modules/inherits": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npm.taobao.org/inherits/download/inherits-2.0.4.tgz?cache=0&sync_timestamp=1560975547815&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Finherits%2Fdownload%2Finherits-2.0.4.tgz",
+            "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
+            "dev": true
+        },
+        "node_modules/minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npm.taobao.org/minimatch/download/minimatch-3.0.4.tgz",
+            "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npm.taobao.org/minimist/download/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "node_modules/mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npm.taobao.org/mkdirp/download/mkdirp-0.5.1.tgz?cache=0&sync_timestamp=1604053732604&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fmkdirp%2Fdownload%2Fmkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "dependencies": {
+                "minimist": "0.0.8"
+            },
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            }
+        },
+        "node_modules/mocha": {
+            "version": "5.2.0",
+            "resolved": "https://registry.nlark.com/mocha/download/mocha-5.2.0.tgz",
+            "integrity": "sha1-bYrlCPWRZ/lA8rWzxKYSrlDJCuY=",
+            "dev": true,
+            "dependencies": {
+                "browser-stdout": "1.3.1",
+                "commander": "2.15.1",
+                "debug": "3.1.0",
+                "diff": "3.5.0",
+                "escape-string-regexp": "1.0.5",
+                "glob": "7.1.2",
+                "growl": "1.10.5",
+                "he": "1.1.1",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "supports-color": "5.4.0"
+            },
+            "bin": {
+                "_mocha": "bin/_mocha",
+                "mocha": "bin/mocha"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.nlark.com/debug/download/debug-3.1.0.tgz?cache=0&sync_timestamp=1618847016785&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fdebug%2Fdownload%2Fdebug-3.1.0.tgz",
+            "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/mocha/node_modules/glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.nlark.com/glob/download/glob-7.1.2.tgz?cache=0&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fglob%2Fdownload%2Fglob-7.1.2.tgz",
+            "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+            "dev": true,
+            "dependencies": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/mocha/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433912031&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.1.2.tgz?cache=0&sync_timestamp=1607433912031&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.1.2.tgz",
+            "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
+            "dev": true
+        },
+        "node_modules/once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npm.taobao.org/once/download/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "dependencies": {
+                "wrappy": "1"
+            }
+        },
+        "node_modules/path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npm.taobao.org/path-is-absolute/download/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/semver": {
+            "version": "5.7.1",
+            "resolved": "https://registry.nlark.com/semver/download/semver-5.7.1.tgz",
+            "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
+            "dev": true,
+            "bin": {
+                "semver": "bin/semver"
+            }
+        },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "http://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
+            "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.19",
+            "resolved": "https://registry.npm.taobao.org/source-map-support/download/source-map-support-0.5.19.tgz",
+            "integrity": "sha1-qYti+G3K9PZzmWSMCFKRq56P7WE=",
+            "dev": true,
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/supports-color": {
+            "version": "5.4.0",
+            "resolved": "https://registry.nlark.com/supports-color/download/supports-color-5.4.0.tgz?cache=0&sync_timestamp=1618846892710&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fsupports-color%2Fdownload%2Fsupports-color-5.4.0.tgz",
+            "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+            "dev": true,
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.2.tgz",
+            "integrity": "sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
+            }
+        },
+        "node_modules/vscode": {
+            "version": "1.1.37",
+            "resolved": "https://registry.npm.taobao.org/vscode/download/vscode-1.1.37.tgz",
+            "integrity": "sha1-wqdwvuS7P/92Xityx7zIE7imuwo=",
+            "dev": true,
+            "dependencies": {
+                "glob": "^7.1.2",
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "mocha": "^5.2.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "vscode-test": "^0.4.1"
+            },
+            "bin": {
+                "vscode-install": "bin/install"
+            },
+            "engines": {
+                "node": ">=8.9.3"
+            }
+        },
+        "node_modules/vscode-test": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npm.taobao.org/vscode-test/download/vscode-test-0.4.3.tgz",
+            "integrity": "sha1-Rh6/JfxLyT132YKu1VZlii4rkLg=",
+            "dev": true,
+            "dependencies": {
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.9.3"
+            }
+        },
+        "node_modules/vscode-test/node_modules/agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npm.taobao.org/agent-base/download/agent-base-4.3.0.tgz",
+            "integrity": "sha1-gWXwHENgCbzK0LHRIvBe13Dvxu4=",
+            "dev": true,
+            "dependencies": {
+                "es6-promisify": "^5.0.0"
+            },
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/vscode-test/node_modules/debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.nlark.com/debug/download/debug-3.1.0.tgz?cache=0&sync_timestamp=1618847016785&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fdebug%2Fdownload%2Fdebug-3.1.0.tgz",
+            "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+            "dev": true,
+            "dependencies": {
+                "ms": "2.0.0"
+            }
+        },
+        "node_modules/vscode-test/node_modules/http-proxy-agent": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npm.taobao.org/http-proxy-agent/download/http-proxy-agent-2.1.0.tgz",
+            "integrity": "sha1-5IIb7vWyFCogJr1zkm/lN2McVAU=",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "4",
+                "debug": "3.1.0"
+            },
+            "engines": {
+                "node": ">= 4.5.0"
+            }
+        },
+        "node_modules/vscode-test/node_modules/https-proxy-agent": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npm.taobao.org/https-proxy-agent/download/https-proxy-agent-2.2.4.tgz",
+            "integrity": "sha1-TuenN6vZJniik9mzShr00NCMeHs=",
+            "dev": true,
+            "dependencies": {
+                "agent-base": "^4.3.0",
+                "debug": "^3.1.0"
+            },
+            "engines": {
+                "node": ">= 4.5.0"
+            }
+        },
+        "node_modules/vscode-test/node_modules/ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npm.taobao.org/ms/download/ms-2.0.0.tgz?cache=0&sync_timestamp=1607433912031&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fms%2Fdownload%2Fms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "node_modules/wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.nlark.com/wrappy/download/wrappy-1.0.2.tgz?cache=0&sync_timestamp=1619133505879&other_urls=https%3A%2F%2Fregistry.nlark.com%2Fwrappy%2Fdownload%2Fwrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        }
+    },
     "dependencies": {
         "@tootallnate/once": {
             "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "background-cover",
     "displayName": "background-cover",
     "description": "Add a picture you like to cover the entire vscode..",
-    "version": "2.2.5",
+    "version": "2.3.0-SNAPSHOT",
     "publisher": "manasxx",
     "engines": {
         "vscode": "^1.38.0"
@@ -54,10 +54,10 @@
                     "default": 0.2,
                     "description": "Background opacity (0 - 1) / 背景透明度(0 - 1)"
                 },
-                "backgroundCover.imagePath": {
+                "backgroundCover.imageUrl": {
                     "type": "string",
                     "default": "",
-                    "description": "Background image path / 背景图片路径"
+                    "description": "Background image url or data (used to sync config) / 背景图片链接或数据(用于同步设置)"
                 },
                 "backgroundCover.randomImageFolder": {
                     "type": "string",

--- a/src/FileDom.ts
+++ b/src/FileDom.ts
@@ -9,12 +9,16 @@ export class FileDom {
 	// 文件路径
 	private filePath = path.join(path.dirname((require.main as NodeModule).filename), 'vs', 'workbench', cssName);
 	private extName = "backgroundCover";
-	private imagePath: string = '';
+	private imageDataOrUrl: string = '';
 	private imageOpacity: number = 1;
 
-
-	constructor(imagePath: string, opacity: number) {
-		this.imagePath = imagePath;
+	/**
+	 * CSS文件操作类
+	 * @param imageDataOrUrl 需要设置的图片数据(^data:)或链接(^https:) 因权限原因不再传入任何(^file:)地址
+	 * @param opacity 需要设置的图片透明度
+	 */
+	constructor(imageDataOrUrl: string, opacity: number) {
+		this.imageDataOrUrl = imageDataOrUrl;
 		this.imageOpacity = opacity;
 	}
 
@@ -46,7 +50,7 @@ export class FileDom {
 			background-size:cover;
 			background-repeat: no-repeat;
 			opacity:${opacity};
-			background-image:url('${this.imagePath}');
+			background-image:url('${this.imageDataOrUrl}');
 		}
 		/*ext-${this.extName}-end*/
 		`;
@@ -54,36 +58,19 @@ export class FileDom {
 
 
 	/**
-    * 获取文件内容
-    * @var mixed
-    */
+	* 获取文件内容
+	* @var mixed
+	*/
 	private getContent(): string {
 		return fs.readFileSync(this.filePath, 'utf-8');
 	}
 
 	/**
-    * 本地图片文件转base64
-    * @var mixed
-    */
-	public imageToBase64(){
-		try{
-			let extname    = path.extname(this.imagePath);
-			extname        = extname.substr(1);
-			this.imagePath = fs.readFileSync(path.resolve(this.imagePath)).toString('base64');
-			this.imagePath = `data:image/${extname};base64,${this.imagePath}`;
-		}catch(e){
-			return false;
-		}
-		
-		return true;
-	}
-
-	/**
-    * 设置文件内容
-    *
-    * @private
-    * @param {string} content
-    */
+	* 设置文件内容
+	*
+	* @private
+	* @param {string} content
+	*/
 	private saveContent(content: string): void {
 		fs.writeFileSync(this.filePath, content, 'utf-8');
 	}


### PR DESCRIPTION
### 新增功能

1. 设置上的背景图片base64保存到config.json里, 启用设置云同步后可以在其它电脑上自动同步修改为新背景图片, 无需手动下载新图片并设置.
2. 每次Code启动时检查当前正在生效的背景图片是否和设置的背景图片一致, 否则提示重启更新. (如当Code升级时会覆盖成无图片,如在其它电脑上更新图片时...)

### 其它

1. 图片保存到config.json里会有很大一坨文本显示在里边, 不过还好只有这一行没有高亮, 其它行配置还是可以继续使用高亮和代码提示功能.
2. https和动态更换功能未测试, 但写代码的时候有考虑.
3. 重命名了以前的"backgroundCover.imageUrl"这个选项...
4. 记得修改插件版本号和更新说明.
5. 有些地方代码不是很优  不知道要不要给你重构了它qaq

